### PR TITLE
feat: migrate to Istio HTTPRoute and add cert-manager Certificate

### DIFF
--- a/charts/minio/templates/certificate.yaml
+++ b/charts/minio/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.minio .Values.cluster_issuer .Values.minio.httproute (and .Values.minio.httproute.enabled .Values.minio.httproute.host) }}
+{{- if and .Values.minio .Values.minio.cluster_issuer .Values.minio.httproute (and .Values.minio.httproute.enabled .Values.minio.httproute.host) }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -8,7 +8,7 @@ metadata:
 spec:
   secretName: {{ .Release.Name }}-tls
   issuerRef:
-    name: {{ .Values.cluster_issuer }}
+    name: {{ .Values.minio.cluster_issuer }}
     kind: ClusterIssuer
   dnsNames:
     - {{ .Values.minio.httproute.host | quote }}

--- a/charts/minio/templates/certificate.yaml
+++ b/charts/minio/templates/certificate.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.minio .Values.cluster_issuer .Values.minio.httproute (and .Values.minio.httproute.enabled .Values.minio.httproute.host) }}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Release.Name }}-tls
+  namespace: {{ .Release.Namespace }}
+spec:
+  secretName: {{ .Release.Name }}-tls
+  issuerRef:
+    name: {{ .Values.cluster_issuer }}
+    kind: ClusterIssuer
+  dnsNames:
+    - {{ .Values.minio.httproute.host | quote }}
+{{- end }}

--- a/charts/minio/templates/httproute.yaml
+++ b/charts/minio/templates/httproute.yaml
@@ -3,11 +3,30 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
+  name: minio-console-http-redirect
+spec:
+  parentRefs:
+    - name: {{ .Values.minio.httproute.gateway_name | default "istio-gateway" }}
+      namespace: {{ .Values.minio.httproute.gateway_namespace | default "istio-ingress" }}
+      sectionName: http
+  hostnames:
+    - {{ .Values.minio.httproute.host | quote }}
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
   name: minio-console
 spec:
   parentRefs:
     - name: {{ .Values.minio.httproute.gateway_name | default "istio-gateway" }}
       namespace: {{ .Values.minio.httproute.gateway_namespace | default "istio-ingress" }}
+      sectionName: https
   hostnames:
     - {{ .Values.minio.httproute.host | quote }}
   rules:

--- a/charts/minio/templates/httproute.yaml
+++ b/charts/minio/templates/httproute.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.minio.httproute.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: minio-console
+spec:
+  parentRefs:
+    - name: {{ .Values.minio.httproute.gateway_name | default "istio-gateway" }}
+      namespace: {{ .Values.minio.httproute.gateway_namespace | default "istio-ingress" }}
+  hostnames:
+    - {{ .Values.minio.httproute.host | quote }}
+  rules:
+    - backendRefs:
+        - name: {{ .Release.Name }}-console
+          port: 9001
+{{- end }}

--- a/charts/minio/templates/httproute.yaml
+++ b/charts/minio/templates/httproute.yaml
@@ -3,24 +3,6 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
-  name: minio-console-http-redirect
-spec:
-  parentRefs:
-    - name: {{ .Values.minio.httproute.gateway_name | default "istio-gateway" }}
-      namespace: {{ .Values.minio.httproute.gateway_namespace | default "istio-ingress" }}
-      sectionName: http
-  hostnames:
-    - {{ .Values.minio.httproute.host | quote }}
-  rules:
-    - filters:
-        - type: RequestRedirect
-          requestRedirect:
-            scheme: https
-            statusCode: 301
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: HTTPRoute
-metadata:
   name: minio-console
 spec:
   parentRefs:

--- a/locals.tf
+++ b/locals.tf
@@ -74,6 +74,7 @@ locals {
         users        = var.config_minio.users
         buckets      = var.config_minio.buckets
         policies     = var.config_minio.policies
+        cluster_issuer = var.cluster_issuer
       },
       local.oidc_config
     )

--- a/locals.tf
+++ b/locals.tf
@@ -28,7 +28,7 @@ locals {
         clientSecret = var.oidc.client_secret
         claimName    = "policy"
         scopes       = "openid,profile,email"
-        redirectUri  = format("https://%s/oauth_callback", local.domain)
+        redirectUri  = format("%s://%s/oauth_callback", split("://", var.oidc.issuer_url)[0], local.domain)
         claimPrefix  = ""
         comment      = ""
       }
@@ -69,11 +69,11 @@ locals {
             public        = true
           }
         }
-        rootUser     = "root"
-        rootPassword = random_password.minio_root_secretkey.result
-        users        = var.config_minio.users
-        buckets      = var.config_minio.buckets
-        policies     = var.config_minio.policies
+        rootUser       = "root"
+        rootPassword   = random_password.minio_root_secretkey.result
+        users          = var.config_minio.users
+        buckets        = var.config_minio.buckets
+        policies       = var.config_minio.policies
         cluster_issuer = var.cluster_issuer
       },
       local.oidc_config

--- a/locals.tf
+++ b/locals.tf
@@ -52,21 +52,13 @@ locals {
           }
         }
         consoleIngress = {
-          enabled = true
-          annotations = {
-            "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
-            "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-            "traefik.ingress.kubernetes.io/router.tls"         = "true"
-          }
-          hosts = [
-            local.domain,
-          ]
-          tls = [{
-            secretName = "minio-tls"
-            hosts = [
-              local.domain,
-            ]
-          }]
+          enabled = false
+        }
+        httproute = {
+          enabled           = true
+          host              = local.domain
+          gateway_name      = "istio-gateway"
+          gateway_namespace = "istio-ingress"
         }
         metrics = {
           serviceMonitor = {

--- a/locals.tf
+++ b/locals.tf
@@ -57,8 +57,8 @@ locals {
         httproute = {
           enabled           = true
           host              = local.domain
-          gateway_name      = "istio-gateway"
-          gateway_namespace = "istio-ingress"
+          gateway_name      = var.gateway_name
+          gateway_namespace = var.gateway_namespace
         }
         metrics = {
           serviceMonitor = {

--- a/variables.tf
+++ b/variables.tf
@@ -151,3 +151,15 @@ variable "oidc" {
 
   default = null
 }
+
+variable "gateway_name" {
+  description = "Name of the Istio Gateway resource to attach HTTPRoutes to."
+  type        = string
+  default     = "istio-gateway"
+}
+
+variable "gateway_namespace" {
+  description = "Namespace where the Istio Gateway resource is deployed."
+  type        = string
+  default     = "istio-ingress"
+}


### PR DESCRIPTION
## Changes

- Migrate from Traefik Ingress to Istio Gateway API HTTPRoute
- Add `gateway_name` and `gateway_namespace` variables
- Add cert-manager Certificate template
- Fix redirect URI scheme based on OIDC issuer URL